### PR TITLE
feat(formatter): add monaco formatter for mdc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,20 @@ monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage);
 
 // Register formatter
 monaco.languages.registerDocumentFormattingEditProvider('mdc', {
-  provideDocumentFormattingEdits: (model) => [{
+  provideDocumentFormattingEdits: model => [{
     range: model.getFullModelRange(),
-    text: markdownFormatter(model.getValue()),
+    text: mdcFormatter(model.getValue(), 2),
+  }],
+});
+
+// Register format on type provider
+monaco.languages.registerOnTypeFormattingEditProvider('mdc', {
+  // Auto-format when the user types a newline character.
+  autoFormatTriggerCharacters: ['\n'],
+  provideOnTypeFormattingEdits: model => [{
+    range: model.getFullModelRange(),
+    // We pass `true` as the third parameter to indicate isFormatOnType
+    text: mdcFormatter(model.getValue(), 2, true),
   }],
 });
 
@@ -51,7 +62,10 @@ const model = monaco.editor.createModel(
 const el = ... // DOM element
 const editor = monaco.editor.create(el, {
   model,
-  // Monaco editor options
+  tabSize: 2,
+  insertSpaces: true, // insert spaces when pressing Tab
+  formatOnType: true, // Add to enable automatic formatting as the user types.
+  // Other Monaco Editor options
   // see: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
 })
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 Integrate MDC syntax with Monaco Editor.
 
-
 ## Installation
 
 ```bash
@@ -20,38 +19,19 @@ npm install @nuxtlabs/monarch-mdc
 
 ## Usage
 
+The package provides both the MDC language syntax for the Monaco Editor, along with an optional formatter function.
+
+Checkout the [Editor.vue](./playground/components/Editor.vue) for a complete example.
+
+### Language
+
 ```js
 import * as monaco from 'monaco-editor'
-import { language as markdownLanguage, formatter as markdownFormatter } from '@nuxtlabs/monarch-mdc'
+import { language as markdownLanguage } from '@nuxtlabs/monarch-mdc'
 
 // Register language
 monaco.languages.register({ id: 'mdc' })
-monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage);
-
-// Register formatter
-monaco.languages.registerDocumentFormattingEditProvider('mdc', {
-  provideDocumentFormattingEdits: model => [{
-    range: model.getFullModelRange(),
-    text: mdcFormatter(model.getValue(), {
-      tabSize: 2,
-    }),
-  }],
-});
-
-// Register format on type provider
-monaco.languages.registerOnTypeFormattingEditProvider('mdc', {
-  // Auto-format when the user types a newline character.
-  autoFormatTriggerCharacters: ['\n'],
-  provideOnTypeFormattingEdits: model => [{
-    range: model.getFullModelRange(),
-    // We pass `true` to `isFormatOnType` to indicate formatOnType is being called.
-    text: mdcFormatter(model.getValue(), {
-      tabSize: 2,
-      isFormatOnType: true,
-    }),
-  }],
-});
-
+monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage)
 
 const code = `
 Your **awesome** markdown
@@ -67,16 +47,78 @@ const model = monaco.editor.createModel(
 const el = ... // DOM element
 const editor = monaco.editor.create(el, {
   model,
-  tabSize: 2,
-  insertSpaces: true, // insert spaces when pressing Tab
+  // Monaco Editor options
+  // see: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
+})
+```
+
+### Formatter
+
+If you'd like to integrate MDC formatting into your Monaco Editor instance, you can also register the formatter provider. The initial setup looks the similar as above for the language syntax, but we'll also register a set or formatting providers.
+
+1. The `registerDocumentFormattingEditProvider` below registers the document format provider which enables the "Format Document" action in the editor's Command Palette along with the built-in keyboard shortcut.
+2. You can also enable the `registerOnTypeFormattingEditProvider` along with the `formatOnType: true` config setting to auto-format the document as the user types. The `autoFormatTriggerCharacters` property allows you to customize the characters that trigger auto-formatting in your editor instance. Below, it is configured to a newline character `/n`, but feel free to customize the options for your project.
+
+Since the format provider utilizes spaces for indention, we will also add a few extra configuration properties to the Monaco Editor instance below.
+
+```js
+import * as monaco from 'monaco-editor'
+import { language as markdownLanguage, formatter as markdownFormatter } from '@nuxtlabs/monarch-mdc'
+
+// Register language
+monaco.languages.register({ id: 'mdc' })
+monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage)
+
+// Define your desired Tab size
+const TAB_SIZE = 2
+
+// Register formatter
+// This enables the "Format Document" action in the editor's Command Palette
+monaco.languages.registerDocumentFormattingEditProvider('mdc', {
+  provideDocumentFormattingEdits: model => [{
+    range: model.getFullModelRange(),
+    text: mdcFormatter(model.getValue(), {
+      tabSize: TAB_SIZE,
+    }),
+  }],
+});
+
+// Register format on type provider
+monaco.languages.registerOnTypeFormattingEditProvider('mdc', {
+  // Auto-format when the user types a newline character.
+  autoFormatTriggerCharacters: ['\n'],
+  provideOnTypeFormattingEdits: model => [{
+    range: model.getFullModelRange(),
+    // We pass `true` to `isFormatOnType` to indicate formatOnType is being called.
+    text: mdcFormatter(model.getValue(), {
+      tabSize: TAB_SIZE,
+      isFormatOnType: true,
+    }),
+  }],
+});
+
+const code = `
+Your **awesome** markdown
+`
+
+// Create monaco model
+const model = monaco.editor.createModel(
+  code,
+  'mdc'
+)
+
+// Create your editor
+const el = ... // DOM element
+const editor = monaco.editor.create(el, {
+  model,
+  tabSize: TAB_SIZE, // Utilize the same tabSize used in the format providers
+  detectIndentation: false, // Important as to not override tabSize
+  insertSpaces: true, // Since the formatter utilizes spaces, we set to true to insert spaces when pressing Tab
   formatOnType: true, // Add to enable automatic formatting as the user types.
   // Other Monaco Editor options
   // see: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
 })
 ```
-
-Checkout the [Editor.vue](./playground/components/Editor.vue) for a complete example.
-
 
 ## 💻 Development
 
@@ -87,7 +129,6 @@ Checkout the [Editor.vue](./playground/components/Editor.vue) for a complete exa
 ## License
 
 [MIT](./LICENSE) - Made with 💚
-
 
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/@nuxtlabs/monarch-mdc/latest.svg

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage);
 monaco.languages.registerDocumentFormattingEditProvider('mdc', {
   provideDocumentFormattingEdits: model => [{
     range: model.getFullModelRange(),
-    text: mdcFormatter(model.getValue(), 2),
+    text: mdcFormatter(model.getValue(), {
+      tabSize: 2,
+    }),
   }],
 });
 
@@ -42,8 +44,11 @@ monaco.languages.registerOnTypeFormattingEditProvider('mdc', {
   autoFormatTriggerCharacters: ['\n'],
   provideOnTypeFormattingEdits: model => [{
     range: model.getFullModelRange(),
-    // We pass `true` as the third parameter to indicate isFormatOnType
-    text: mdcFormatter(model.getValue(), 2, true),
+    // We pass `true` to `isFormatOnType` to indicate formatOnType is being called.
+    text: mdcFormatter(model.getValue(), {
+      tabSize: 2,
+      isFormatOnType: true,
+    }),
   }],
 });
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ const editor = monaco.editor.create(el, {
 
 ### Formatter
 
-If you'd like to integrate MDC formatting into your Monaco Editor instance, you can also register the formatter provider. The initial setup looks the similar as above for the language syntax, but we'll also register a set or formatting providers.
+If you'd like to integrate MDC formatting into your Monaco Editor instance, you can also register the document format provider. The initial setup looks similar, but we'll also register a set of formatting providers and some additional editor instance config options.
 
-1. The `registerDocumentFormattingEditProvider` below registers the document format provider which enables the "Format Document" action in the editor's Command Palette along with the built-in keyboard shortcut.
-2. You can also enable the `registerOnTypeFormattingEditProvider` along with the `formatOnType: true` config setting to auto-format the document as the user types. The `autoFormatTriggerCharacters` property allows you to customize the characters that trigger auto-formatting in your editor instance. Below, it is configured to a newline character `/n`, but feel free to customize the options for your project.
+1. The `registerDocumentFormattingEditProvider` registers the document format provider which enables the "Format Document" action in the editor's Command Palette along with the built-in keyboard shortcut.
+2. You can also enable the `registerOnTypeFormattingEditProvider` along with enabling the `formatOnType` config setting to auto-format the document as the user types. The `autoFormatTriggerCharacters` property allows you to customize the characters that trigger auto-formatting in your editor instance. Below, it is configured to a newline character `/n`, but feel free to customize the options for your project.
 
 > [!Note]
-> Since the format provider utilizes spaces for indention, we will also add a few **required** configuration properties to the Monaco Editor instance below.
+> Since the format provider utilizes spaces for indention, we will also configure the editor to insert spaces for tabs.
 
 ```js
 import * as monaco from 'monaco-editor'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage);
 monaco.languages.registerDocumentFormattingEditProvider('mdc', {
   provideDocumentFormattingEdits: (model) => [{
     range: model.getFullModelRange(),
-    text: formatter(model.getValue()),
+    text: markdownFormatter(model.getValue()),
   }],
 });
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Integrate MDC syntax with Monaco Editor.
 ## Installation
 
 ```bash
+#using pnpm
+pnpm add @nuxtlabs/monarch-mdc
 #using yarn
 yarn add @nuxtlabs/monarch-mdc
 # using npm
@@ -20,11 +22,19 @@ npm install @nuxtlabs/monarch-mdc
 
 ```js
 import * as monaco from 'monaco-editor'
-import { language as markdownLanguage } from '@nuxtlabs/monarch-mdc'
+import { language as markdownLanguage, formatter as markdownFormatter } from '@nuxtlabs/monarch-mdc'
 
 // Register language
 monaco.languages.register({ id: 'mdc' })
 monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage);
+
+// Register formatter
+monaco.languages.registerDocumentFormattingEditProvider('mdc', {
+  provideDocumentFormattingEdits: (model) => [{
+    range: model.getFullModelRange(),
+    text: formatter(model.getValue()),
+  }],
+});
 
 
 const code = `
@@ -41,7 +51,7 @@ const model = monaco.editor.createModel(
 const el = ... // DOM element
 const editor = monaco.editor.create(el, {
   model,
-  // Monaco edito options
+  // Monaco editor options
   // see: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
 })
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ If you'd like to integrate MDC formatting into your Monaco Editor instance, you 
 1. The `registerDocumentFormattingEditProvider` below registers the document format provider which enables the "Format Document" action in the editor's Command Palette along with the built-in keyboard shortcut.
 2. You can also enable the `registerOnTypeFormattingEditProvider` along with the `formatOnType: true` config setting to auto-format the document as the user types. The `autoFormatTriggerCharacters` property allows you to customize the characters that trigger auto-formatting in your editor instance. Below, it is configured to a newline character `/n`, but feel free to customize the options for your project.
 
-Since the format provider utilizes spaces for indention, we will also add a few extra configuration properties to the Monaco Editor instance below.
+> [!Note]
+> Since the format provider utilizes spaces for indention, we will also add a few **required** configuration properties to the Monaco Editor instance below.
 
 ```js
 import * as monaco from 'monaco-editor'

--- a/package.json
+++ b/package.json
@@ -12,15 +12,19 @@
   "scripts": {
     "dev": "nuxi dev playground",
     "lint": "eslint .",
+    "test": "vitest run --passWithNoTests",
+    "test:ui": "vitest --ui --passWithNoTests",
     "build": "unbuild",
-    "release": "release-it"
+    "release": "pnpm test && release-it"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^0.7.3",
+    "@vitest/ui": "^2.1.8",
     "eslint": "^9.17.0",
     "monaco-editor-core": "^0.52.2",
     "release-it": "^17.10.0",
-    "unbuild": "^3.0.1"
+    "unbuild": "^3.0.1",
+    "vitest": "^2.1.8"
   },
   "packageManager": "pnpm@9.15.0",
   "release-it": {

--- a/playground/components/Editor.vue
+++ b/playground/components/Editor.vue
@@ -40,7 +40,17 @@ onMounted(async () => {
   monaco.languages.registerDocumentFormattingEditProvider('mdc', {
     provideDocumentFormattingEdits: model => [{
       range: model.getFullModelRange(),
-      text: mdcFormatter(model.getValue()),
+      text: mdcFormatter(model.getValue(), 2),
+    }],
+  })
+  // Register format on type provider
+  monaco.languages.registerOnTypeFormattingEditProvider('mdc', {
+    // Auto-format when the user types a newline character.
+    autoFormatTriggerCharacters: ['\n'],
+    provideOnTypeFormattingEdits: model => [{
+      range: model.getFullModelRange(),
+      // We pass `true` as the third parameter to indicate isFormatOnType
+      text: mdcFormatter(model.getValue(), 2, true),
     }],
   })
 
@@ -63,6 +73,8 @@ onMounted(async () => {
     bracketPairColorization: {
       enabled: true,
     },
+    tabSize: 2,
+    insertSpaces: true, // insert spaces when pressing Tab
     formatOnPaste: true,
     formatOnType: true,
   })

--- a/playground/components/Editor.vue
+++ b/playground/components/Editor.vue
@@ -40,7 +40,9 @@ onMounted(async () => {
   monaco.languages.registerDocumentFormattingEditProvider('mdc', {
     provideDocumentFormattingEdits: model => [{
       range: model.getFullModelRange(),
-      text: mdcFormatter(model.getValue(), 2),
+      text: mdcFormatter(model.getValue(), {
+        tabSize: 2,
+      }),
     }],
   })
   // Register format on type provider
@@ -49,8 +51,11 @@ onMounted(async () => {
     autoFormatTriggerCharacters: ['\n'],
     provideOnTypeFormattingEdits: model => [{
       range: model.getFullModelRange(),
-      // We pass `true` as the third parameter to indicate isFormatOnType
-      text: mdcFormatter(model.getValue(), 2, true),
+      // We pass `true` to `isFormatOnType` to indicate formatOnType is being called.
+      text: mdcFormatter(model.getValue(), {
+        tabSize: 2,
+        isFormatOnType: true,
+      }),
     }],
   })
 

--- a/playground/components/Editor.vue
+++ b/playground/components/Editor.vue
@@ -8,7 +8,7 @@
 <script setup>
 import { ref, onMounted, watch } from 'vue'
 import loader from '@monaco-editor/loader'
-import { language as mdc } from '../../src/index'
+import { language as mdc, formatter as mdcFormatter } from '../../src/index'
 
 const props = defineProps({
   code: {
@@ -35,6 +35,14 @@ onMounted(async () => {
   // Register the MDC language
   monaco.languages.register({ id: 'mdc' })
   monaco.languages.setMonarchTokensProvider('mdc', mdc)
+
+  // Register formatter
+  monaco.languages.registerDocumentFormattingEditProvider('mdc', {
+    provideDocumentFormattingEdits: model => [{
+      range: model.getFullModelRange(),
+      text: mdcFormatter(model.getValue()),
+    }],
+  })
 
   editor = monaco.editor.create(editorContainer.value, {
     value: props.code,

--- a/playground/components/Editor.vue
+++ b/playground/components/Editor.vue
@@ -36,12 +36,15 @@ onMounted(async () => {
   monaco.languages.register({ id: 'mdc' })
   monaco.languages.setMonarchTokensProvider('mdc', mdc)
 
+  // Define your desired Tab size
+  const TAB_SIZE = 2
+
   // Register formatter
   monaco.languages.registerDocumentFormattingEditProvider('mdc', {
     provideDocumentFormattingEdits: model => [{
       range: model.getFullModelRange(),
       text: mdcFormatter(model.getValue(), {
-        tabSize: 2,
+        tabSize: TAB_SIZE,
       }),
     }],
   })
@@ -53,7 +56,7 @@ onMounted(async () => {
       range: model.getFullModelRange(),
       // We pass `true` to `isFormatOnType` to indicate formatOnType is being called.
       text: mdcFormatter(model.getValue(), {
-        tabSize: 2,
+        tabSize: TAB_SIZE,
         isFormatOnType: true,
       }),
     }],
@@ -78,10 +81,11 @@ onMounted(async () => {
     bracketPairColorization: {
       enabled: true,
     },
-    tabSize: 2,
-    insertSpaces: true, // insert spaces when pressing Tab
+    tabSize: TAB_SIZE, // Utilize the same tabSize used in the format providers
+    detectIndentation: false, // Important as to not override tabSize
+    insertSpaces: true, // Since the formatter utilizes spaces, we set to true to insert spaces when pressing Tab
+    formatOnType: true, // Add to enable automatic formatting as the user types.
     formatOnPaste: true,
-    formatOnType: true,
   })
 
   editor.onDidChangeModelContent(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@nuxt/eslint-config':
         specifier: ^0.7.3
         version: 0.7.3(@vue/compiler-sfc@3.5.13)(eslint@9.17.0(jiti@2.4.1))(typescript@5.2.2)
+      '@vitest/ui':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8)
       eslint:
         specifier: ^9.17.0
         version: 9.17.0(jiti@2.4.1)
@@ -23,6 +26,9 @@ importers:
       unbuild:
         specifier: ^3.0.1
         version: 3.0.1(typescript@5.2.2)(vue@3.5.13(typescript@5.2.2))
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@22.10.2)(@vitest/ui@2.1.8)(lightningcss@1.28.2)(terser@5.37.0)
 
   playground:
     dependencies:
@@ -658,9 +664,6 @@ packages:
 
   '@jridgewell/source-map@0.3.6':
     resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
-
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -1348,6 +1351,40 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@2.1.8':
+    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+
+  '@vitest/mocker@2.1.8':
+    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.8':
+    resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
+
+  '@vitest/runner@2.1.8':
+    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+
+  '@vitest/snapshot@2.1.8':
+    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
+
+  '@vitest/spy@2.1.8':
+    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+
+  '@vitest/ui@2.1.8':
+    resolution: {integrity: sha512-5zPJ1fs0ixSVSs5+5V2XJjXLmNzjugHRyV11RqxYVR+oMcogZ9qTuSfKW+OcTV0JeFNznI83BNylzH6SSNJ1+w==}
+    peerDependencies:
+      vitest: 2.1.8
+
+  '@vitest/utils@2.1.8':
+    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
+
   '@vue-macros/common@1.15.1':
     resolution: {integrity: sha512-O0ZXaladWXwHplQnSjxLbB/G1KpdWCUNJPNYVHIxHonGex1BGpoB4fBZZLgddHgAiy18VZG/Iu5L0kwG+SV7JQ==}
     engines: {node: '>=16.14.0'}
@@ -1568,6 +1605,10 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@1.3.2:
     resolution: {integrity: sha512-gdvX700WVC6sHCJQ7bJGfDvtuKAh6Sa6weIZROxfzUZKP7BjvB8y0SMlM/o4omSQ3L60PQSJROBJsb0vEViVnA==}
     engines: {node: '>=16.14.0'}
@@ -1706,6 +1747,10 @@ packages:
   caniuse-lite@1.0.30001688:
     resolution: {integrity: sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==}
 
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+    engines: {node: '>=12'}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1723,6 +1768,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2033,6 +2082,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2411,6 +2464,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -2447,6 +2504,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3120,6 +3180,9 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3579,6 +3642,10 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -4084,6 +4151,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -4162,6 +4232,9 @@ packages:
 
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -4318,12 +4391,27 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.1:
     resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -4677,6 +4765,31 @@ packages:
       terser:
         optional: true
 
+  vitest@2.1.8:
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@6.0.0:
     resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
     engines: {node: '>=8.0.0 || >=10.0.0'}
@@ -4764,6 +4877,11 @@ packages:
   which@3.0.1:
     resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -5394,7 +5512,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.19
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -5414,14 +5532,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.19':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -6440,6 +6556,57 @@ snapshots:
       vite: 5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
       vue: 3.5.13(typescript@5.2.2)
 
+  '@vitest/expect@2.1.8':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.15
+    optionalDependencies:
+      vite: 5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
+
+  '@vitest/pretty-format@2.1.8':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.8':
+    dependencies:
+      '@vitest/utils': 2.1.8
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      magic-string: 0.30.15
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.8':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/ui@2.1.8(vitest@2.1.8)':
+    dependencies:
+      '@vitest/utils': 2.1.8
+      fflate: 0.8.2
+      flatted: 3.3.2
+      pathe: 1.1.2
+      sirv: 3.0.0
+      tinyglobby: 0.2.10
+      tinyrainbow: 1.2.0
+      vitest: 2.1.8(@types/node@22.10.2)(@vitest/ui@2.1.8)(lightningcss@1.28.2)(terser@5.37.0)
+
+  '@vitest/utils@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+
   '@vue-macros/common@1.15.1(rollup@4.28.1)(vue@3.5.13(typescript@5.2.2))':
     dependencies:
       '@babel/types': 7.26.3
@@ -6706,6 +6873,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@1.3.2:
     dependencies:
       '@babel/parser': 7.26.3
@@ -6861,6 +7030,14 @@ snapshots:
 
   caniuse-lite@1.0.30001688: {}
 
+  chai@5.1.2:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.2
+      pathval: 2.0.0
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -6877,6 +7054,8 @@ snapshots:
   change-case@5.4.4: {}
 
   chardet@0.7.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7151,7 +7330,7 @@ snapshots:
 
   debug@3.2.7:
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
 
   debug@4.3.4:
     dependencies:
@@ -7162,6 +7341,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 9.4.0
+
+  deep-eql@5.0.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -7640,6 +7821,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expect-type@1.1.0: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -7678,6 +7861,8 @@ snapshots:
   fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8318,6 +8503,8 @@ snapshots:
       chalk: 5.3.0
       is-unicode-supported: 1.3.0
 
+  loupe@3.1.2: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -8950,6 +9137,8 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathval@2.0.0: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.0.0: {}
@@ -9514,6 +9703,8 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -9592,6 +9783,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   stable-hash@0.0.4: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -9754,12 +9947,20 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.1: {}
 
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.0.2: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
@@ -10158,6 +10359,42 @@ snapshots:
       lightningcss: 1.28.2
       terser: 5.37.0
 
+  vitest@2.1.8(@types/node@22.10.2)(@vitest/ui@2.1.8)(lightningcss@1.28.2)(terser@5.37.0):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.4.0(supports-color@9.4.0)
+      expect-type: 1.1.0
+      magic-string: 0.30.15
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.11(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
+      vite-node: 2.1.8(@types/node@22.10.2)(lightningcss@1.28.2)(terser@5.37.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.10.2
+      '@vitest/ui': 2.1.8(vitest@2.1.8)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vscode-jsonrpc@6.0.0: {}
 
   vscode-languageclient@7.0.0:
@@ -10243,6 +10480,11 @@ snapshots:
   which@3.0.1:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/src/formatter.spec.ts
+++ b/src/formatter.spec.ts
@@ -15,7 +15,7 @@ describe('MDC Formatter', () => {
       const expected = `::button
 content
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components', () => {
@@ -37,7 +37,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components and inline components', () => {
@@ -71,7 +71,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -79,13 +79,13 @@ More outer content.
     it('formats simple inline component', () => {
       const input = ':icon'
       const expected = ':icon'
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats simple inline component with props', () => {
       const input = ':icon{ name="mdi:github" }'
       const expected = ':icon{ name="mdi:github" }'
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats top-level inline component', () => {
@@ -97,7 +97,7 @@ More outer content.
 
 :icon
 `
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats top-level inline component with props', () => {
@@ -109,7 +109,7 @@ More outer content.
 
 :icon{ name="mdi:github" }
 `
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats a nested inline component with props', () => {
@@ -129,7 +129,7 @@ Container content.
 :icon{ name="mdi:github" }
 ::
 `
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -151,7 +151,7 @@ image:
 ---
 Slot content.
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats a nested block component with YAML nested props', () => {
@@ -173,7 +173,7 @@ Slot content.
   Slot content.
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats YAML with multiline strings', () => {
@@ -197,7 +197,7 @@ styles: |
   }
 ---
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components with YAML and multiline strings', () => {
@@ -233,7 +233,7 @@ styles: |
   ---
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -341,7 +341,7 @@ padding: "20px"
   Another paragraph below the alert.
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -365,7 +365,7 @@ function test() {
 }
 \`\`\`
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('handles deeply nested code blocks', () => {
@@ -391,7 +391,7 @@ if (true) {
     ::::
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -421,7 +421,7 @@ styles: >
   ---
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -445,7 +445,7 @@ content
     ::::
   :::
 ::`
-      expect(formatter(input, 2)).toBe(expected)
+      expect(formatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 })

--- a/src/formatter.spec.ts
+++ b/src/formatter.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { formatter } from './formatter'
+import { formatter as mdcFormatter } from './formatter'
 
 describe('MDC Formatter', () => {
   describe('Block Components', () => {
@@ -15,7 +15,7 @@ describe('MDC Formatter', () => {
       const expected = `::button
 content
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components', () => {
@@ -37,7 +37,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components and inline components', () => {
@@ -71,7 +71,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -79,13 +79,13 @@ More outer content.
     it('formats simple inline component', () => {
       const input = ':icon'
       const expected = ':icon'
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats simple inline component with props', () => {
       const input = ':icon{ name="mdi:github" }'
       const expected = ':icon{ name="mdi:github" }'
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats top-level inline component', () => {
@@ -97,7 +97,7 @@ More outer content.
 
 :icon
 `
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats top-level inline component with props', () => {
@@ -109,7 +109,7 @@ More outer content.
 
 :icon{ name="mdi:github" }
 `
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats a nested inline component with props', () => {
@@ -129,7 +129,7 @@ Container content.
 :icon{ name="mdi:github" }
 ::
 `
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -151,7 +151,7 @@ image:
 ---
 Slot content.
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats a nested block component with YAML nested props', () => {
@@ -173,7 +173,7 @@ Slot content.
   Slot content.
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats YAML with multiline strings', () => {
@@ -197,7 +197,7 @@ styles: |
   }
 ---
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('formats nested block components with YAML and multiline strings', () => {
@@ -233,7 +233,7 @@ styles: |
   ---
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -341,7 +341,7 @@ padding: "20px"
   Another paragraph below the alert.
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -365,7 +365,7 @@ function test() {
 }
 \`\`\`
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
 
     it('handles deeply nested code blocks', () => {
@@ -391,7 +391,7 @@ if (true) {
     ::::
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -421,7 +421,7 @@ styles: >
   ---
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 
@@ -445,7 +445,7 @@ content
     ::::
   :::
 ::`
-      expect(formatter(input, { tabSize: 2 })).toBe(expected)
+      expect(mdcFormatter(input, { tabSize: 2 })).toBe(expected)
     })
   })
 })

--- a/src/formatter.spec.ts
+++ b/src/formatter.spec.ts
@@ -15,7 +15,7 @@ describe('MDC Formatter', () => {
       const expected = `::button
 content
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats nested block components', () => {
@@ -37,7 +37,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats nested block components and inline components', () => {
@@ -71,7 +71,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -79,13 +79,13 @@ More outer content.
     it('formats simple inline component', () => {
       const input = ':icon'
       const expected = ':icon'
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats simple inline component with props', () => {
       const input = ':icon{ name="mdi:github" }'
       const expected = ':icon{ name="mdi:github" }'
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats top-level inline component', () => {
@@ -97,7 +97,7 @@ More outer content.
 
 :icon
 `
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats top-level inline component with props', () => {
@@ -109,7 +109,7 @@ More outer content.
 
 :icon{ name="mdi:github" }
 `
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats a nested inline component with props', () => {
@@ -129,7 +129,7 @@ Container content.
 :icon{ name="mdi:github" }
 ::
 `
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -151,7 +151,7 @@ image:
 ---
 Slot content.
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats a nested block component with YAML nested props', () => {
@@ -173,7 +173,7 @@ Slot content.
   Slot content.
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats YAML with multiline strings', () => {
@@ -197,7 +197,7 @@ styles: |
   }
 ---
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('formats nested block components with YAML and multiline strings', () => {
@@ -205,11 +205,15 @@ styles: |
 :::container
 ---
 styles: |
-color: red;
+  color: red;
 
-.my-class {
-  background-color: blue;
-}
+  .my-class {
+    background-color: blue;
+
+    .another-class {
+      content: '';
+    }
+  }
 ---
 :::
 ::`
@@ -220,12 +224,16 @@ color: red;
     color: red;
 
     .my-class {
-    background-color: blue;
+      background-color: blue;
+
+      .another-class {
+        content: '';
+      }
     }
   ---
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -333,7 +341,7 @@ padding: "20px"
   Another paragraph below the alert.
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -357,7 +365,7 @@ function test() {
 }
 \`\`\`
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
 
     it('handles deeply nested code blocks', () => {
@@ -383,7 +391,7 @@ if (true) {
     ::::
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -413,7 +421,7 @@ styles: >
   ---
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 
@@ -437,7 +445,7 @@ content
     ::::
   :::
 ::`
-      expect(formatter(input)).toBe(expected)
+      expect(formatter(input, 2)).toBe(expected)
     })
   })
 })

--- a/src/formatter.spec.ts
+++ b/src/formatter.spec.ts
@@ -4,25 +4,22 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import formatMDC from './formatter'
+import { formatter } from './formatter'
 
 describe('MDC Formatter', () => {
   describe('Block Components', () => {
     it('formats single block component with content', () => {
-      const input
-= `::button
+      const input = `::button
   content
 ::`
-      const expected
-= `::button
+      const expected = `::button
 content
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats nested block components', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 # This is a header
 
 ::container
@@ -31,8 +28,7 @@ This is nested content.
 
 More outer content.
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
 # This is a header
 
   ::container
@@ -41,12 +37,11 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats nested block components and inline components', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 # This is a header
 
 ::container
@@ -61,8 +56,7 @@ This is nested another level
 
 More outer content.
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
 # This is a header
 
   ::container
@@ -77,7 +71,7 @@ More outer content.
 
 More outer content.
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
@@ -85,46 +79,41 @@ More outer content.
     it('formats simple inline component', () => {
       const input = ':icon'
       const expected = ':icon'
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats simple inline component with props', () => {
       const input = ':icon{ name="mdi:github" }'
       const expected = ':icon{ name="mdi:github" }'
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats top-level inline component', () => {
-      const input
-= `# This is a header
+      const input = `# This is a header
 
   :icon
 `
-      const expected
-= `# This is a header
+      const expected = `# This is a header
 
 :icon
 `
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats top-level inline component with props', () => {
-      const input
-= `# This is a header
+      const input = `# This is a header
 
   :icon{ name="mdi:github" }
 `
-      const expected
-= `# This is a header
+      const expected = `# This is a header
 
 :icon{ name="mdi:github" }
 `
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats a nested inline component with props', () => {
-      const input
-= `# This is a header
+      const input = `# This is a header
 
 ::container
   Container content.
@@ -132,8 +121,7 @@ More outer content.
 :icon{ name="mdi:github" }
 ::
 `
-      const expected
-= `# This is a header
+      const expected = `# This is a header
 
 ::container
 Container content.
@@ -141,14 +129,13 @@ Container content.
 :icon{ name="mdi:github" }
 ::
 `
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
   describe('YAML Frontmatter', () => {
     it('formats simple YAML block', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 ---
 background-color: "red"
 image:
@@ -156,8 +143,7 @@ image:
 ---
 Slot content.
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
 ---
 background-color: "red"
 image:
@@ -165,12 +151,11 @@ image:
 ---
 Slot content.
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats a nested block component with YAML nested props', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 :::container
 ---
 image:
@@ -179,8 +164,7 @@ image:
 Slot content.
 :::
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
   :::container
   ---
   image:
@@ -189,12 +173,11 @@ Slot content.
   Slot content.
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats YAML with multiline strings', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 ---
 styles: |
   color: red;
@@ -204,8 +187,7 @@ styles: |
   }
 ---
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
 ---
 styles: |
   color: red;
@@ -215,12 +197,11 @@ styles: |
   }
 ---
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('formats nested block components with YAML and multiline strings', () => {
-      const input
-= `::page-section
+      const input = `::page-section
 :::container
 ---
 styles: |
@@ -232,8 +213,7 @@ color: red;
 ---
 :::
 ::`
-      const expected
-= `::page-section
+      const expected = `::page-section
   :::container
   ---
   styles: |
@@ -245,14 +225,13 @@ color: red;
   ---
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
   describe('Mixed Content', () => {
     it('formats complex nested structure', () => {
-      const input
-= `::container
+      const input = `::container
 ---
 background-color: "#eee"
 padding: "20px"
@@ -303,8 +282,7 @@ This is the alert message.
 Another paragraph below the alert.
 :::
 ::`
-      const expected
-= `::container
+      const expected = `::container
 ---
 background-color: "#eee"
 padding: "20px"
@@ -355,14 +333,13 @@ padding: "20px"
   Another paragraph below the alert.
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
   describe('Code Blocks', () => {
     it('preserves empty lines in code blocks', () => {
-      const input
-= `::container
+      const input = `::container
 \`\`\`js
 function test() {
 
@@ -371,8 +348,7 @@ function test() {
 }
 \`\`\`
 ::`
-      const expected
-= `::container
+      const expected = `::container
 \`\`\`js
 function test() {
 
@@ -381,12 +357,11 @@ function test() {
 }
 \`\`\`
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
 
     it('handles deeply nested code blocks', () => {
-      const input
-= `::container
+      const input = `::container
 :::child
 ::::grand-child
 \`\`\`js
@@ -397,8 +372,7 @@ if (true) {
 ::::
 :::
 ::`
-      const expected
-= `::container
+      const expected = `::container
   :::child
     ::::grand-child
     \`\`\`js
@@ -409,14 +383,13 @@ if (true) {
     ::::
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
   describe('Complex YAML', () => {
     it('handles multiple multiline strings', () => {
-      const input
-= `::container
+      const input = `::container
 :::container
 ---
 styles: >
@@ -428,8 +401,7 @@ styles: >
 ---
 :::
 ::`
-      const expected
-= `::container
+      const expected = `::container
   :::container
   ---
   styles: >
@@ -441,14 +413,13 @@ styles: >
   ---
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 
   describe('Mixed Content', () => {
     it('handles deep nesting with mixed components', () => {
-      const input
-= `::level-1
+      const input = `::level-1
 :inline1{prop="value"}
 :::level-2
 :inline2{prop="value"}
@@ -457,8 +428,7 @@ content
 ::::
 :::
 ::`
-      const expected
-= `::level-1
+      const expected = `::level-1
 :inline1{prop="value"}
   :::level-2
   :inline2{prop="value"}
@@ -467,7 +437,7 @@ content
     ::::
   :::
 ::`
-      expect(formatMDC(input)).toBe(expected)
+      expect(formatter(input)).toBe(expected)
     })
   })
 })

--- a/src/formatter.spec.ts
+++ b/src/formatter.spec.ts
@@ -1,0 +1,473 @@
+/**
+ * Important: the formatting in this file is crucial for the test cases.
+ * Be careful when re-formatting any of the markdown input/expected blocks.
+ */
+
+import { describe, it, expect } from 'vitest'
+import formatMDC from './formatter'
+
+describe('MDC Formatter', () => {
+  describe('Block Components', () => {
+    it('formats single block component with content', () => {
+      const input
+= `::button
+  content
+::`
+      const expected
+= `::button
+content
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats nested block components', () => {
+      const input
+= `::page-section
+# This is a header
+
+::container
+This is nested content.
+::
+
+More outer content.
+::`
+      const expected
+= `::page-section
+# This is a header
+
+  ::container
+  This is nested content.
+  ::
+
+More outer content.
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats nested block components and inline components', () => {
+      const input
+= `::page-section
+# This is a header
+
+::container
+This is nested content.
+
+:::button
+This is nested another level
+:::
+::
+
+:icon{ name="mdi:github" }
+
+More outer content.
+::`
+      const expected
+= `::page-section
+# This is a header
+
+  ::container
+  This is nested content.
+
+    :::button
+    This is nested another level
+    :::
+  ::
+
+:icon{ name="mdi:github" }
+
+More outer content.
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('Inline Components', () => {
+    it('formats simple inline component', () => {
+      const input = ':icon'
+      const expected = ':icon'
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats simple inline component with props', () => {
+      const input = ':icon{ name="mdi:github" }'
+      const expected = ':icon{ name="mdi:github" }'
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats top-level inline component', () => {
+      const input
+= `# This is a header
+
+  :icon
+`
+      const expected
+= `# This is a header
+
+:icon
+`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats top-level inline component with props', () => {
+      const input
+= `# This is a header
+
+  :icon{ name="mdi:github" }
+`
+      const expected
+= `# This is a header
+
+:icon{ name="mdi:github" }
+`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats a nested inline component with props', () => {
+      const input
+= `# This is a header
+
+::container
+  Container content.
+
+:icon{ name="mdi:github" }
+::
+`
+      const expected
+= `# This is a header
+
+::container
+Container content.
+
+:icon{ name="mdi:github" }
+::
+`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('YAML Frontmatter', () => {
+    it('formats simple YAML block', () => {
+      const input
+= `::page-section
+---
+background-color: "red"
+image:
+  url: "https://example.com/image.png"
+---
+Slot content.
+::`
+      const expected
+= `::page-section
+---
+background-color: "red"
+image:
+  url: "https://example.com/image.png"
+---
+Slot content.
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats a nested block component with YAML nested props', () => {
+      const input
+= `::page-section
+:::container
+---
+image:
+  url: "https://example.com/image.png"
+---
+Slot content.
+:::
+::`
+      const expected
+= `::page-section
+  :::container
+  ---
+  image:
+    url: "https://example.com/image.png"
+  ---
+  Slot content.
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats YAML with multiline strings', () => {
+      const input
+= `::page-section
+---
+styles: |
+  color: red;
+
+  .my-class {
+    background-color: blue;
+  }
+---
+::`
+      const expected
+= `::page-section
+---
+styles: |
+  color: red;
+
+  .my-class {
+    background-color: blue;
+  }
+---
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('formats nested block components with YAML and multiline strings', () => {
+      const input
+= `::page-section
+:::container
+---
+styles: |
+color: red;
+
+.my-class {
+  background-color: blue;
+}
+---
+:::
+::`
+      const expected
+= `::page-section
+  :::container
+  ---
+  styles: |
+    color: red;
+
+    .my-class {
+    background-color: blue;
+    }
+  ---
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('Mixed Content', () => {
+    it('formats complex nested structure', () => {
+      const input
+= `::container
+---
+background-color: "#eee"
+padding: "20px"
+---
+# This is a header
+
+:icon{ name="mdi:github" size="36px" color="#000" }
+
+:::container
+---
+padding: "0px"
+---
+::::container
+---
+styles: |
+  pre {
+    border: 1px solid red !important;
+
+    span {
+      line-height: 1;
+    }
+  }
+---
+This container has a code block.
+
+\`\`\`js
+function test() {
+  console.log("test");
+}
+\`\`\`
+
+And an inline component:
+
+:icon{ name="mdi:github" size="36px" color="#000" }
+
+And an alert:
+
+:::::alert
+---
+appearance: "success"
+show-icon: true
+---
+This is the alert message.
+:::::
+
+::::
+
+Another paragraph below the alert.
+:::
+::`
+      const expected
+= `::container
+---
+background-color: "#eee"
+padding: "20px"
+---
+# This is a header
+
+:icon{ name="mdi:github" size="36px" color="#000" }
+
+  :::container
+  ---
+  padding: "0px"
+  ---
+    ::::container
+    ---
+    styles: |
+      pre {
+        border: 1px solid red !important;
+
+        span {
+          line-height: 1;
+        }
+      }
+    ---
+    This container has a code block.
+
+    \`\`\`js
+    function test() {
+      console.log("test");
+    }
+    \`\`\`
+
+    And an inline component:
+
+    :icon{ name="mdi:github" size="36px" color="#000" }
+
+    And an alert:
+
+      :::::alert
+      ---
+      appearance: "success"
+      show-icon: true
+      ---
+      This is the alert message.
+      :::::
+
+    ::::
+
+  Another paragraph below the alert.
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('Code Blocks', () => {
+    it('preserves empty lines in code blocks', () => {
+      const input
+= `::container
+\`\`\`js
+function test() {
+
+  console.log("test");
+
+}
+\`\`\`
+::`
+      const expected
+= `::container
+\`\`\`js
+function test() {
+
+  console.log("test");
+
+}
+\`\`\`
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+
+    it('handles deeply nested code blocks', () => {
+      const input
+= `::container
+:::child
+::::grand-child
+\`\`\`js
+if (true) {
+  console.log("nested");
+}
+\`\`\`
+::::
+:::
+::`
+      const expected
+= `::container
+  :::child
+    ::::grand-child
+    \`\`\`js
+    if (true) {
+      console.log("nested");
+    }
+    \`\`\`
+    ::::
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('Complex YAML', () => {
+    it('handles multiple multiline strings', () => {
+      const input
+= `::container
+:::container
+---
+styles: >
+  color: red;
+
+  .another-class {
+    background-color: blue;
+  }
+---
+:::
+::`
+      const expected
+= `::container
+  :::container
+  ---
+  styles: >
+    color: red;
+
+    .another-class {
+      background-color: blue;
+    }
+  ---
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+
+  describe('Mixed Content', () => {
+    it('handles deep nesting with mixed components', () => {
+      const input
+= `::level-1
+:inline1{prop="value"}
+:::level-2
+:inline2{prop="value"}
+::::level-3
+content
+::::
+:::
+::`
+      const expected
+= `::level-1
+:inline1{prop="value"}
+  :::level-2
+  :inline2{prop="value"}
+    ::::level-3
+    content
+    ::::
+  :::
+::`
+      expect(formatMDC(input)).toBe(expected)
+    })
+  })
+})

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,4 +1,14 @@
 /**
+ * Formatter Options
+ */
+interface FormatterOptions {
+  /** The number of spaces to use for indentation. Defaults to `2`. */
+  tabSize?: number
+  /** Whether the formatter is being used for on-type formatting. Defaults to `false`. */
+  isFormatOnType?: boolean
+}
+
+/**
  * Tracks YAML block state including base indentation and
  * special handling for multiline string content
  */
@@ -41,7 +51,7 @@ function getIndent(spaces: number): string {
  * @param {number} tabSize - The number of spaces to use for indentation. Defaults to `2`.
  * @param {boolean} isFormatOnType - Whether the formatter is being used for on-type formatting. Defaults to `false`.
  */
-export const formatter = (content: string, tabSize: number = 2, isFormatOnType: boolean = false): string => {
+export const formatter = (content: string, { tabSize = 2, isFormatOnType = false }: FormatterOptions): string => {
   // Split input into lines and pre-allocate output array
   const lines = content.split('\n')
   const formattedLines = Array.from({ length: lines.length })

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -48,8 +48,9 @@ function getIndent(spaces: number): string {
  * - Nested MDC block components
  *
  * @param {string} content - The raw MDC content to format
- * @param {number} tabSize - The number of spaces to use for indentation. Defaults to `2`.
- * @param {boolean} isFormatOnType - Whether the formatter is being used for on-type formatting. Defaults to `false`.
+ * @param {FormatterOptions} options - The formatter options
+ * @param {number} options.tabSize - The number of spaces to use for indentation. Defaults to `2`.
+ * @param {boolean} options.isFormatOnType - Whether the formatter is being used for on-type formatting. Defaults to `false`.
  */
 export const formatter = (content: string, { tabSize = 2, isFormatOnType = false }: FormatterOptions): string => {
   // Split input into lines and pre-allocate output array

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,178 @@
+/**
+ * Tracks YAML block state including base indentation and
+ * special handling for multiline string content
+ */
+interface YamlState {
+  // Base indentation level for YAML block
+  baseIndent: number | null
+  // Starting indent for multiline strings
+  multilineBaseIndent: number | null
+  // Minimum required indent for multiline content
+  multilineMinimumIndent: number | null
+}
+
+const INDENT_SPACES = 2
+
+// Regular expressions for detecting different MDC elements
+const INDENT_REGEX = /^\s*/
+// Matches block component opening tags like "::name"
+const COMPONENT_START_REGEX = /^\s*:{2,}[\w-]+/
+// Matches block component closing tags like "::"
+const COMPONENT_END_REGEX = /^\s*:{2,}\s*$/
+// Matches YAML multiline indicators "|" or ">"
+const MULTILINE_STRING_REGEX = /^[\w-]+:\s*[|>]/
+
+/**
+ * Cache for commonly used indentation strings to avoid repeated string creation
+ */
+const indentCache: { [key: number]: string } = {}
+function getIndent(spaces: number): string {
+  if (!indentCache[spaces]) {
+    indentCache[spaces] = ' '.repeat(spaces)
+  }
+  return indentCache[spaces]
+}
+
+/**
+ * MDC Formatter: Handles formatting and indentation of MDC files which contain:
+ * - MDC block components
+ * - MDC block component YAML frontmatter, including multiline strings
+ * - Nested MDC block components
+ */
+export const formatter = (content: string): string => {
+  // Split input into lines and pre-allocate output array
+  const lines = content.split('\n')
+  const formattedLines = Array.from({ length: lines.length })
+  // Tracks nested component indentation levels
+  const componentIndentStack: number[] = []
+
+  // State tracking variables
+
+  // Current indentation level
+  let currentIndent = 0
+  // Whether we're inside YAML frontmatter
+  let insideYamlBlock = false
+  // Whether we're inside a YAML multiline string
+  let insideMultilineString = false
+  // Whether we're inside a markdown code block
+  let insideCodeBlock = false
+  // Current position in output array
+  let formattedIndex = 0
+
+  // Add new state variable at top of function
+  let codeBlockBaseIndent: number | null = null
+
+  const yamlState: YamlState = {
+    baseIndent: null,
+    multilineBaseIndent: null,
+    multilineMinimumIndent: null,
+  }
+
+  // Process each line
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    // Leading whitespace count
+    const indent = line.match(INDENT_REGEX)?.[0].length || 0
+    const trimmedContent = line.trim()
+    // Current component's indent level
+    const parentIndent = componentIndentStack[componentIndentStack.length - 1] || 0
+
+    // Return empty lines without indentation
+    if (trimmedContent === '') {
+      formattedLines[formattedIndex++] = ''
+      continue
+    }
+
+    // Handle code block markers (```)
+    if (trimmedContent.startsWith('```')) {
+      insideCodeBlock = !insideCodeBlock
+      if (insideCodeBlock) {
+        // Store base indent when entering code block
+        codeBlockBaseIndent = indent
+      }
+      else {
+        // Reset when leaving code block
+        codeBlockBaseIndent = null
+      }
+      formattedLines[formattedIndex++] = getIndent(parentIndent) + trimmedContent
+      continue
+    }
+
+    // Preserve indentation inside code blocks
+    if (insideCodeBlock) {
+      if (trimmedContent === '') {
+        formattedLines[formattedIndex++] = ''
+        continue
+      }
+      // Calculate relative indent from code block's base
+      const relativeIndent = indent - (codeBlockBaseIndent || 0)
+      // Add parent indent to preserve relative structure
+      formattedLines[formattedIndex++] = getIndent(parentIndent + relativeIndent) + trimmedContent
+      continue
+    }
+
+    // Handle YAML frontmatter markers
+    if (trimmedContent === '---') {
+      insideYamlBlock = !insideYamlBlock
+      insideMultilineString = false
+      yamlState.multilineBaseIndent = null
+      yamlState.multilineMinimumIndent = null
+      yamlState.baseIndent = insideYamlBlock ? indent : null
+      formattedLines[formattedIndex++] = getIndent(parentIndent) + '---'
+      continue
+    }
+
+    // Handle component opening tags (::component-name)
+    if (COMPONENT_START_REGEX.test(line)) {
+      formattedLines[formattedIndex++] = getIndent(currentIndent) + trimmedContent
+      // Save current indent level for nested components
+      componentIndentStack.push(currentIndent)
+      // Increase indent for component content
+      currentIndent += INDENT_SPACES
+      continue
+    }
+
+    // Handle component closing tags (::)
+    if (COMPONENT_END_REGEX.test(line)) {
+      // Restore previous indent level
+      currentIndent = componentIndentStack.pop() || 0
+      formattedLines[formattedIndex++] = getIndent(currentIndent) + trimmedContent
+      continue
+    }
+
+    // Process YAML block content
+    if (insideYamlBlock && trimmedContent) {
+      // Handle start of multiline string (using | or > indicators)
+      if (MULTILINE_STRING_REGEX.test(trimmedContent)) {
+        insideMultilineString = true
+        // Store original indent level
+        yamlState.multilineBaseIndent = indent
+        // Ensure minimum INDENT_SPACES space indent
+        yamlState.multilineMinimumIndent = parentIndent + INDENT_SPACES
+        formattedLines[formattedIndex++] = getIndent(parentIndent) + trimmedContent
+        continue
+      }
+
+      // Handle content within multiline strings
+      if (insideMultilineString && yamlState.multilineBaseIndent !== null) {
+        // Calculate relative indentation from original multiline base
+        const relativeIndent = indent - yamlState.multilineBaseIndent
+        // Ensure minimum indent while preserving relative structure
+        const finalIndent = Math.max(yamlState.multilineMinimumIndent!, parentIndent + relativeIndent)
+        formattedLines[formattedIndex++] = getIndent(finalIndent) + line.slice(indent)
+        continue
+      }
+
+      if (yamlState.baseIndent !== null) {
+        const relativeIndent = indent - yamlState.baseIndent
+        formattedLines[formattedIndex++] = getIndent(parentIndent + relativeIndent) + trimmedContent
+        continue
+      }
+    }
+
+    formattedLines[formattedIndex++] = getIndent(parentIndent) + trimmedContent
+  }
+
+  formattedLines.length = formattedIndex
+  return formattedLines.join('\n')
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -60,9 +60,9 @@ export const formatter = (content: string, tabSize: number = 2, isFormatOnType: 
   let insideCodeBlock = false
   // Current position in output array
   let formattedIndex = 0
-
-  // Add new state variable at top of function
+  // Base indent for the current markdown code block
   let codeBlockBaseIndent: number | null = null
+  // The original indent of the markdown code block line
   let codeBlockOriginalIndent: number | null = null
 
   const yamlState: YamlState = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,3 +251,5 @@ export const language = <languages.IMonarchLanguage>{
     ],
   },
 }
+
+export { formatter } from './formatter'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.ts'],
+  },
+})


### PR DESCRIPTION
Adds a `monaco-editor` formatting provider, along with updated usage instructions and unit tests.