### PR TITLE
fix(formatter): properly indent nested yaml props

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -59,6 +59,8 @@ const UNORDERED_LIST_REGEX = /^\s*[-*]\s+/
 const ORDERED_LIST_REGEX = /^\s*\d+\.\s+/
 // Matches task list items like "- [ ] item" or "* [x] item"
 const TASK_LIST_REGEX = /^\s*[-*]\s+\[.\]\s+/
+// Matches parent properties (property ending with ":" without a value)
+const PARENT_PROPERTY_REGEX = /^[\w-]+:\s*$/
 
 /**
  * Cache for commonly used indentation strings to avoid repeated string creation
@@ -106,6 +108,9 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
   let codeBlockBaseIndent: number | null = null
   let codeBlockOriginalIndent: number | null = null
 
+  // Track parent property state
+  let lastParentProperty = false
+
   const yamlState: YamlState = {
     baseIndent: null,
     multilineBaseIndent: null,
@@ -114,6 +119,10 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
 
   let listState: ListState | null = null
   let currentComponentId = 0 // Unique ID for each component level
+
+  // Add state variable to track the YAML front matter's intended indentation
+  // This will be the indentation we want for YAML blocks regardless of what's in the input
+  let yamlIntendedIndent: number | null = null
 
   // Process each line
   for (let i = 0; i < lines.length; i++) {
@@ -172,7 +181,18 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
       insideMultilineString = false
       yamlState.multilineBaseIndent = null
       yamlState.multilineMinimumIndent = null
+
       yamlState.baseIndent = insideYamlBlock ? indent : null
+
+      // But also track the intended indentation as the parent component's indent
+      if (insideYamlBlock) {
+        yamlIntendedIndent = parentIndent
+      }
+      else {
+        yamlIntendedIndent = null
+      }
+
+      lastParentProperty = false // Reset parent property tracking
       formattedLines[formattedIndex++] = getIndent(parentIndent) + '---'
       continue
     }
@@ -202,7 +222,7 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
     if (insideYamlBlock) {
       if (trimmedContent) {
         // Check if we're exiting a multiline string
-        if (insideMultilineString && indent === yamlState.baseIndent && trimmedContent.includes(':')) {
+        if (insideMultilineString && indent <= yamlState.baseIndent! && trimmedContent.includes(':')) {
           insideMultilineString = false
           yamlState.multilineBaseIndent = null
           yamlState.multilineMinimumIndent = null
@@ -216,6 +236,7 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
           // Ensure minimum tabSize space indent
           yamlState.multilineMinimumIndent = parentIndent + tabSize
           formattedLines[formattedIndex++] = getIndent(parentIndent) + trimmedContent
+          lastParentProperty = false // Reset parent property tracking
           continue
         }
 
@@ -229,14 +250,52 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
           continue
         }
 
-        // Adjust indentation for YAML block content based on the base indent level
+        // If not in a multiline string, check for parent properties and children
+        if (!insideMultilineString) {
+          // Check if this is a parent property (property with no value after the colon)
+          if (PARENT_PROPERTY_REGEX.test(trimmedContent)) {
+            // Use yamlIntendedIndent (parentIndent) instead of yamlState.baseIndent
+            formattedLines[formattedIndex++] = getIndent(yamlIntendedIndent!) + trimmedContent
+            lastParentProperty = true
+            continue
+          }
+
+          // Check if this is a child property (after a parent property)
+          if (lastParentProperty && trimmedContent.includes(':')) {
+            // Use yamlIntendedIndent + tabSize for child properties
+            formattedLines[formattedIndex++] = getIndent(yamlIntendedIndent! + tabSize) + trimmedContent
+            lastParentProperty = PARENT_PROPERTY_REGEX.test(trimmedContent) // Check if this is also a parent
+            continue
+          }
+
+          // If this is content after a parent property but not a property itself
+          if (lastParentProperty) {
+            formattedLines[formattedIndex++] = getIndent(yamlIntendedIndent! + tabSize) + trimmedContent
+            continue
+          }
+
+          // For normal YAML properties, use the base indentation
+          if (trimmedContent.includes(':') && !trimmedContent.startsWith('-')) {
+            // Use yamlIntendedIndent instead of yamlState.baseIndent
+            formattedLines[formattedIndex++] = getIndent(yamlIntendedIndent!) + trimmedContent
+            // Reset parent property tracking for normal properties
+            lastParentProperty = false
+            continue
+          }
+        }
+
+        // For nested properties or lists, adjust indentation based on the base indent level
         if (yamlState.baseIndent !== null) {
+          // Always make sure we're using at least parentIndent as the base
+          const effectiveBaseIndent = Math.max(yamlState.baseIndent, parentIndent)
           const relativeIndent = indent - yamlState.baseIndent
-          formattedLines[formattedIndex++] = getIndent(Math.max(yamlState.baseIndent, parentIndent + relativeIndent)) + trimmedContent
+          // Use yamlIntendedIndent as the base instead of yamlState.baseIndent
+          formattedLines[formattedIndex++] = getIndent(yamlIntendedIndent! + Math.max(0, relativeIndent)) + trimmedContent
           continue
         }
       }
       else {
+        // Empty line - don't reset lastParentProperty to allow for multi-line content blocks
         // Indent empty lines at the same level as the previous line
         if (isFormatOnType) {
           // If inside a multiline string, ensure minimum indentation
@@ -279,6 +338,7 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
       const finalIndent = listState.componentLevel + (nestLevel * tabSize)
 
       formattedLines[formattedIndex++] = getIndent(finalIndent) + trimmedContent
+      lastParentProperty = false // Reset parent property tracking
       continue
     }
     else if (!trimmedContent && listState) {
@@ -290,6 +350,7 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
     }
 
     formattedLines[formattedIndex++] = getIndent(parentIndent) + trimmedContent
+    lastParentProperty = false // Reset parent property tracking
   }
 
   formattedLines.length = formattedIndex

--- a/tests/content/input/14.preserves empty lines in code blocks.md
+++ b/tests/content/input/14.preserves empty lines in code blocks.md
@@ -1,8 +1,8 @@
 ::container
-```js
+```ts
 function test() {
-
-  console.log("test");
+  const name: string = 'My Name';
+  console.log("name", name);
 
 }
 ```

--- a/tests/content/input/17.handles deep nesting with mixed components.md
+++ b/tests/content/input/17.handles deep nesting with mixed components.md
@@ -5,6 +5,7 @@
 ::::level-3
 ---
 foo: "bar"
+parent-foo:
   child-foo: "child-bar"
 ---
 content

--- a/tests/content/input/19.properly formats YAML with wrong initial indentation and child props.md
+++ b/tests/content/input/19.properly formats YAML with wrong initial indentation and child props.md
@@ -1,0 +1,24 @@
+::container
+---
+  foo: "bar"
+  another: "property"
+  background-image:
+    url: "https://example.com"
+  styles: |
+    p {
+      color: red;
+    }
+---
+::container
+---
+    foo: "bar"
+    another: "property"
+    background-image:
+      url: "https://example.com"
+    styles: |
+      p {
+        color: red;
+      }
+---
+::
+::

--- a/tests/content/input/20.formats nested props with too much indentation.md
+++ b/tests/content/input/20.formats nested props with too much indentation.md
@@ -1,0 +1,30 @@
+::page-section
+---
+full-width: true
+---
+  ::page-hero
+  ---
+    full-width: true
+    title-font-size: "clamp(24px, 5vw, 32px)"
+    title-tag: "h2"
+    text-align: "left"
+    title-line-height: "clamp(32px, 3vw, 40px)"
+    title-font-weight: "700"
+    description-font-weight: "400"
+    description-font-size: "clamp(16px, 3vw, 18px)"
+    description-line-height: "clamp(24px, 3vw, 32px)"
+    background-image:
+      url: "https://example.com/background.png"
+    styles: |
+      p {
+        color: var(--kui-color-text-neutral-stronger);
+      }
+
+  ---
+  #title
+  Getting started
+
+  #description
+  General information and Tips and Tricks
+  ::
+::

--- a/tests/content/output/14.preserves empty lines in code blocks.md
+++ b/tests/content/output/14.preserves empty lines in code blocks.md
@@ -1,8 +1,8 @@
 ::container
-```js
+```ts
 function test() {
-
-  console.log("test");
+  const name: string = 'My Name';
+  console.log("name", name);
 
 }
 ```

--- a/tests/content/output/17.handles deep nesting with mixed components.md
+++ b/tests/content/output/17.handles deep nesting with mixed components.md
@@ -5,6 +5,7 @@
     ::::level-3
     ---
     foo: "bar"
+    parent-foo:
       child-foo: "child-bar"
     ---
     content

--- a/tests/content/output/19.properly formats YAML with wrong initial indentation and child props.md
+++ b/tests/content/output/19.properly formats YAML with wrong initial indentation and child props.md
@@ -1,0 +1,24 @@
+::container
+---
+foo: "bar"
+another: "property"
+background-image:
+  url: "https://example.com"
+styles: |
+  p {
+    color: red;
+  }
+---
+  ::container
+  ---
+  foo: "bar"
+  another: "property"
+  background-image:
+    url: "https://example.com"
+  styles: |
+    p {
+      color: red;
+    }
+  ---
+  ::
+::

--- a/tests/content/output/20.formats nested props with too much indentation.md
+++ b/tests/content/output/20.formats nested props with too much indentation.md
@@ -1,0 +1,30 @@
+::page-section
+---
+full-width: true
+---
+  ::page-hero
+  ---
+  full-width: true
+  title-font-size: "clamp(24px, 5vw, 32px)"
+  title-tag: "h2"
+  text-align: "left"
+  title-line-height: "clamp(32px, 3vw, 40px)"
+  title-font-weight: "700"
+  description-font-weight: "400"
+  description-font-size: "clamp(16px, 3vw, 18px)"
+  description-line-height: "clamp(24px, 3vw, 32px)"
+  background-image:
+    url: "https://example.com/background.png"
+  styles: |
+    p {
+      color: var(--kui-color-text-neutral-stronger);
+    }
+
+  ---
+  #title
+  Getting started
+
+  #description
+  General information and Tips and Tricks
+  ::
+::


### PR DESCRIPTION
In some scenarios, improperly indented YAML props were not auto-formatted back to their original location. 

The new test case `20.formats nested props with too much indentation.md` covers the exact scenario.