### PR TITLE
chore(build): ensure we build before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run --passWithNoTests",
     "test:ui": "vitest --ui --passWithNoTests",
     "build": "unbuild",
-    "release": "pnpm test && release-it"
+    "release": "pnpm build && pnpm test && release-it"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^1.3.0",


### PR DESCRIPTION
Add the `build` command to the `release` step to prevent releasing without first building the updated code.