### PR TITLE
fix(formatting): multiple nested properties

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
-  - "./"
-  - "playground"
+  - ./
+  - playground
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -274,8 +274,7 @@ export const formatter = (content: string, { tabSize = 2, isFormatOnType = false
           const isParentProp = PARENT_PROPERTY_REGEX.test(trimmedContent)
 
           // Remove properties from stack that are at the same or deeper indentation
-          while (propertyStack.length > 0
-            && propertyStack[propertyStack.length - 1].indent >= currentIndent) {
+          while (propertyStack.length > 0 && propertyStack[propertyStack.length - 1].indent >= currentIndent) {
             propertyStack.pop()
           }
 

--- a/tests/content/input/10.formats a nested block component with YAML nested props.md
+++ b/tests/content/input/10.formats a nested block component with YAML nested props.md
@@ -3,6 +3,7 @@
 ---
 image:
   url: "https://example.com/image.png"
+  alt: "Alt text"
 ---
 Slot content.
 :::

--- a/tests/content/input/17.handles deep nesting with mixed components.md
+++ b/tests/content/input/17.handles deep nesting with mixed components.md
@@ -7,6 +7,7 @@
 foo: "bar"
 parent-foo:
   child-foo: "child-bar"
+  another-child: "even-more"
 ---
 content
 ::::

--- a/tests/content/input/19.properly formats YAML with wrong initial indentation and child props.md
+++ b/tests/content/input/19.properly formats YAML with wrong initial indentation and child props.md
@@ -4,6 +4,7 @@
   another: "property"
   background-image:
     url: "https://example.com"
+    background-size: "contain"
   styles: |
     p {
       color: red;
@@ -15,6 +16,7 @@
     another: "property"
     background-image:
       url: "https://example.com"
+      background-size: "contain"
     styles: |
       p {
         color: red;

--- a/tests/content/input/20.formats nested props with too much indentation.md
+++ b/tests/content/input/20.formats nested props with too much indentation.md
@@ -15,6 +15,7 @@ full-width: true
     description-line-height: "clamp(24px, 3vw, 32px)"
     background-image:
       url: "https://example.com/background.png"
+      background-size: "contain"
     styles: |
       p {
         color: var(--kui-color-text-neutral-stronger);

--- a/tests/content/input/21.formats props with multiple child props.md
+++ b/tests/content/input/21.formats props with multiple child props.md
@@ -1,0 +1,23 @@
+::page-hero
+---
+title-font-size: "72px"
+title-line-height: "72px"
+description-font-size: "24px"
+description-line-height: "32px"
+text-align: "left"
+padding: "50px 0 0 0"
+styles: |
+  position: relative;
+  p {
+    color: rgb(88 89 100)
+  }
+image:
+  max-width: "30%"
+  position: right
+---
+#title
+The developer infrastructure bank
+
+#description
+The only nationally chartered bank built to enable developers and builders to create new financial products
+::

--- a/tests/content/input/22.formats nested component props with multiple child props.md
+++ b/tests/content/input/22.formats nested component props with multiple child props.md
@@ -1,0 +1,25 @@
+::container
+::page-hero
+---
+title-font-size: "72px"
+title-line-height: "72px"
+description-font-size: "24px"
+description-line-height: "32px"
+text-align: "left"
+padding: "50px 0 0 0"
+styles: |
+  position: relative;
+  p {
+    color: rgb(88 89 100)
+  }
+image:
+  max-width: "30%"
+  position: right
+---
+#title
+The developer infrastructure bank
+
+#description
+The only nationally chartered bank built to enable developers and builders to create new financial products
+::
+::

--- a/tests/content/output/10.formats a nested block component with YAML nested props.md
+++ b/tests/content/output/10.formats a nested block component with YAML nested props.md
@@ -3,6 +3,7 @@
   ---
   image:
     url: "https://example.com/image.png"
+    alt: "Alt text"
   ---
   Slot content.
   :::

--- a/tests/content/output/17.handles deep nesting with mixed components.md
+++ b/tests/content/output/17.handles deep nesting with mixed components.md
@@ -7,6 +7,7 @@
     foo: "bar"
     parent-foo:
       child-foo: "child-bar"
+      another-child: "even-more"
     ---
     content
     ::::

--- a/tests/content/output/19.properly formats YAML with wrong initial indentation and child props.md
+++ b/tests/content/output/19.properly formats YAML with wrong initial indentation and child props.md
@@ -4,6 +4,7 @@ foo: "bar"
 another: "property"
 background-image:
   url: "https://example.com"
+  background-size: "contain"
 styles: |
   p {
     color: red;
@@ -15,6 +16,7 @@ styles: |
   another: "property"
   background-image:
     url: "https://example.com"
+    background-size: "contain"
   styles: |
     p {
       color: red;

--- a/tests/content/output/20.formats nested props with too much indentation.md
+++ b/tests/content/output/20.formats nested props with too much indentation.md
@@ -15,6 +15,7 @@ full-width: true
   description-line-height: "clamp(24px, 3vw, 32px)"
   background-image:
     url: "https://example.com/background.png"
+    background-size: "contain"
   styles: |
     p {
       color: var(--kui-color-text-neutral-stronger);

--- a/tests/content/output/21.formats props with multiple child props.md
+++ b/tests/content/output/21.formats props with multiple child props.md
@@ -1,0 +1,23 @@
+::page-hero
+---
+title-font-size: "72px"
+title-line-height: "72px"
+description-font-size: "24px"
+description-line-height: "32px"
+text-align: "left"
+padding: "50px 0 0 0"
+styles: |
+  position: relative;
+  p {
+    color: rgb(88 89 100)
+  }
+image:
+  max-width: "30%"
+  position: right
+---
+#title
+The developer infrastructure bank
+
+#description
+The only nationally chartered bank built to enable developers and builders to create new financial products
+::

--- a/tests/content/output/22.formats nested component props with multiple child props.md
+++ b/tests/content/output/22.formats nested component props with multiple child props.md
@@ -1,0 +1,25 @@
+::container
+  ::page-hero
+  ---
+  title-font-size: "72px"
+  title-line-height: "72px"
+  description-font-size: "24px"
+  description-line-height: "32px"
+  text-align: "left"
+  padding: "50px 0 0 0"
+  styles: |
+    position: relative;
+    p {
+      color: rgb(88 89 100)
+    }
+  image:
+    max-width: "30%"
+    position: right
+  ---
+  #title
+  The developer infrastructure bank
+
+  #description
+  The only nationally chartered bank built to enable developers and builders to create new financial products
+  ::
+::


### PR DESCRIPTION
If the MDC component prop has multiple children, the second child prop was being "unindented" a level.

This PR ensures the formatting for consecutive child props is correct.