### PR TITLE
feat: mdc block component tag matching and highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ const editor = monaco.editor.create(el, {
 
 ### Bracket Matching
 
-If you'd like to highlight matching opening and closing brackets for MDC block components, you can register the bracket matcher. This will highlight both brackets when the cursor is adjacent to either one.
+If you'd like to highlight matching opening and closing MDC block component tags, you can register the bracket matcher. This will highlight the opening `::component-name` and closing `::` when the cursor is adjacent to either one.
 
 ```js
 import * as monaco from 'monaco-editor'

--- a/README.md
+++ b/README.md
@@ -170,9 +170,51 @@ const editor = monaco.editor.create(el, {
 })
 ```
 
+### Bracket Matching
+
+If you'd like to highlight matching opening and closing brackets for MDC block components, you can register the bracket matcher. This will highlight both brackets when the cursor is adjacent to either one.
+
+```js
+import * as monaco from 'monaco-editor'
+import { language as markdownLanguage, registerBracketMatcher } from '@nuxtlabs/monarch-mdc'
+
+// Register language
+monaco.languages.register({ id: 'mdc' })
+monaco.languages.setMonarchTokensProvider('mdc', markdownLanguage)
+
+const code = `
+::component
+Your **awesome** markdown
+::
+`
+
+// Create monaco model
+const model = monaco.editor.createModel(
+  code,
+  'mdc'
+)
+
+// Create your editor
+const el = ... // DOM element
+const editor = monaco.editor.create(el, {
+  model,
+  // Monaco Editor options
+  // see: https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandaloneeditorconstructionoptions.html
+})
+
+// Register bracket matcher (with optional configuration)
+const bracketMatcherDisposable = registerBracketMatcher(editor, {
+  injectStyles: true, // Auto-inject default styles (default: true)
+  maxLineCount: 5000, // Disable for large documents (default: 5000, set to 0 to disable limit)
+})
+
+// Clean up when disposing the editor
+// bracketMatcherDisposable.dispose()
+```
+
 ## VS Code Extension
 
-The exported `formatter` and `getDocumentFoldingRanges` functions are also utilized in [@nuxtlabs/vscode-mdc](https://github.com/nuxtlabs/vscode-mdc) to provide the functionality to the [MDC VS Code extension](https://marketplace.visualstudio.com/items?itemName=Nuxt.mdc).
+The exported `formatter`, `getDocumentFoldingRanges`, and `findMatchingBrackets` functions are also utilized in [@nuxtlabs/vscode-mdc](https://github.com/nuxtlabs/vscode-mdc) to provide the functionality to the [MDC VS Code extension](https://marketplace.visualstudio.com/items?itemName=Nuxt.mdc).
 
 ## 💻 Development
 

--- a/playground/components/Editor.vue
+++ b/playground/components/Editor.vue
@@ -6,12 +6,13 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import loader from '@monaco-editor/loader'
 import {
   language as mdc,
   formatter as mdcFormatter,
   foldingProvider as mdcFoldingProvider,
+  registerBracketMatcher,
 } from '../../src/index'
 
 const props = defineProps({
@@ -32,6 +33,7 @@ const props = defineProps({
 const emit = defineEmits(['update:code'])
 const editorContainer = ref(null)
 let editor = null
+let bracketMatcherDisposable = null
 
 onMounted(async () => {
   const monaco = await loader.init()
@@ -114,6 +116,16 @@ onMounted(async () => {
   editor.onDidChangeModelContent(() => {
     emit('update:code', editor.getValue())
   })
+
+  // Initialize bracket matcher for MDC block components
+  bracketMatcherDisposable = registerBracketMatcher(editor)
+})
+
+onBeforeUnmount(() => {
+  if (bracketMatcherDisposable) {
+    bracketMatcherDisposable.dispose()
+    bracketMatcherDisposable = null
+  }
 })
 
 watch(() => props.code, (newCode) => {

--- a/src/bracket-matcher.ts
+++ b/src/bracket-matcher.ts
@@ -1,0 +1,238 @@
+import type { editor } from 'monaco-editor-core'
+import type { TextDocument, Position } from './find-matching-brackets'
+import { findMatchingBrackets } from './find-matching-brackets'
+
+/**
+ * Injects CSS styles for bracket matching into the document if not already present.
+ * Uses Monaco's standard bracket matching colors for visual consistency.
+ */
+function injectStyles() {
+  const styleId = 'mdc-bracket-matcher-styles'
+
+  // Check if running in browser environment
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const doc = (globalThis as any).document
+  if (typeof doc === 'undefined') {
+    return
+  }
+
+  // Check if styles already injected
+  if (doc.getElementById(styleId)) {
+    return
+  }
+
+  const style = doc.createElement('style')
+  style.id = styleId
+  style.textContent = `
+    .mdc-bracket-match {
+      background-color: rgba(0, 122, 204, 0.1) !important;
+      border: 1px solid rgba(0, 122, 204, 0.8) !important;
+      box-sizing: border-box !important;
+    }
+
+    .mdc-bracket-match-inline {
+      font-weight: 600;
+    }
+  `
+
+  doc.head.appendChild(style)
+}
+
+/**
+ * Options for customizing bracket matcher appearance and behavior.
+ */
+export interface BracketMatcherOptions {
+  /**
+   * CSS class name for matched bracket decorations.
+   * If not provided, default styles will be used.
+   * @default 'mdc-bracket-match'
+   */
+  className?: string
+
+  /**
+   * Inline CSS class name for matched bracket decorations.
+   * @default 'mdc-bracket-match-inline'
+   */
+  inlineClassName?: string
+
+  /**
+   * Whether to automatically inject default styles into the document.
+   * Set to false if you want to provide your own CSS.
+   * @default true
+   */
+  injectStyles?: boolean
+
+  /**
+   * Maximum number of lines to scan for bracket matching.
+   * Bracket matching will be disabled for documents exceeding this limit
+   * to maintain performance. Set to 0 to disable the limit.
+   * @default 5000
+   */
+  maxLineCount?: number
+}
+
+/**
+ * Disposable object for cleaning up bracket matcher resources.
+ */
+export interface BracketMatcherDisposable {
+  /**
+   * Removes all event listeners and decorations.
+   */
+  dispose: () => void
+}
+
+const DEFAULT_OPTIONS: Required<BracketMatcherOptions> = {
+  className: 'mdc-bracket-match',
+  inlineClassName: 'mdc-bracket-match-inline',
+  injectStyles: true,
+  maxLineCount: 5000,
+}
+
+/**
+ * Registers a bracket matcher for MDC block components in Monaco Editor.
+ *
+ * The bracket matcher highlights matching opening and closing `::` markers when the cursor
+ * is adjacent to them. It automatically injects the necessary CSS styles unless disabled.
+ *
+ * @example
+ * ```typescript
+ * import { registerBracketMatcher } from '@nuxtlabs/monarch-mdc'
+ *
+ * const disposable = registerBracketMatcher(editor, {
+ *   injectStyles: true, // default
+ *   maxLineCount: 5000, // default, disables for large documents
+ * })
+ *
+ * // Clean up when done
+ * disposable.dispose()
+ * ```
+ *
+ * @param monacoEditor - The Monaco editor instance to attach the bracket matcher to
+ * @param options - Configuration options for the bracket matcher
+ * @returns A disposable object that can be used to clean up the bracket matcher
+ */
+export function registerBracketMatcher(
+  monacoEditor: editor.ICodeEditor,
+  options?: BracketMatcherOptions,
+): BracketMatcherDisposable {
+  const opts = { ...DEFAULT_OPTIONS, ...options }
+
+  // Inject default styles if enabled
+  if (opts.injectStyles) {
+    injectStyles()
+  }
+
+  let decorations: string[] = []
+
+  /**
+   * Adapts Monaco's ITextModel to the TextDocument interface.
+   */
+  function createTextDocument(model: editor.ITextModel): TextDocument {
+    return {
+      getLine: (lineNumber: number) => model.getLineContent(lineNumber + 1), // Monaco uses 1-based line numbers
+      lineCount: model.getLineCount(),
+    }
+  }
+
+  /**
+   * Adapts Monaco's Position to the Position interface.
+   */
+  function createPosition(position: { lineNumber: number, column: number }): Position {
+    return {
+      line: position.lineNumber - 1, // Convert to 0-based
+      column: position.column - 1, // Convert to 0-based
+    }
+  }
+
+  /**
+   * Update bracket decorations based on cursor position.
+   */
+  function updateBracketDecorations(position: { lineNumber: number, column: number }) {
+    try {
+      const model = monacoEditor.getModel()
+      if (!model) {
+        return
+      }
+
+      // Performance safeguard: skip bracket matching for very large documents
+      if (opts.maxLineCount > 0 && model.getLineCount() > opts.maxLineCount) {
+        // Clear any existing decorations
+        decorations = model.deltaDecorations(decorations, [])
+        return
+      }
+
+      // Adapt Monaco types to editor-agnostic interfaces
+      const document = createTextDocument(model)
+      const pos = createPosition(position)
+      const match = findMatchingBrackets(document, pos)
+
+      if (!match) {
+        // Clear decorations if no match found
+        decorations = model.deltaDecorations(decorations, [])
+        return
+      }
+
+      // Create decoration options - always use CSS classes for styling
+      const decorationOptions: editor.IModelDecorationOptions = {
+        className: opts.className,
+        inlineClassName: opts.inlineClassName,
+        stickiness: 1, // TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges
+      }
+
+      // Apply decorations to both opening and closing brackets (convert 0-based to 1-based)
+      decorations = model.deltaDecorations(decorations, [
+        {
+          range: {
+            startLineNumber: match.opening.startLine + 1,
+            startColumn: match.opening.startColumn + 1,
+            endLineNumber: match.opening.endLine + 1,
+            endColumn: match.opening.endColumn + 1,
+          },
+          options: decorationOptions,
+        },
+        {
+          range: {
+            startLineNumber: match.closing.startLine + 1,
+            startColumn: match.closing.startColumn + 1,
+            endLineNumber: match.closing.endLine + 1,
+            endColumn: match.closing.endColumn + 1,
+          },
+          options: decorationOptions,
+        },
+      ])
+    }
+    catch (error) {
+      // Fail silently to avoid breaking the editor
+      console.warn('[MDC Bracket Matcher] Error updating decorations:', error)
+      // Clear any existing decorations on error
+      const model = monacoEditor.getModel()
+      if (model && decorations.length > 0) {
+        decorations = model.deltaDecorations(decorations, [])
+      }
+    }
+  }
+
+  // Listen to cursor position changes
+  const cursorDisposable = monacoEditor.onDidChangeCursorPosition((e) => {
+    updateBracketDecorations(e.position)
+  })
+
+  // Initial update based on current cursor position
+  const currentPosition = monacoEditor.getPosition()
+  if (currentPosition) {
+    updateBracketDecorations(currentPosition)
+  }
+
+  // Return disposable
+  return {
+    dispose: () => {
+      cursorDisposable.dispose()
+
+      const model = monacoEditor.getModel()
+      if (model) {
+        model.deltaDecorations(decorations, [])
+      }
+      decorations = []
+    },
+  }
+}

--- a/src/find-matching-brackets.test.ts
+++ b/src/find-matching-brackets.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from 'vitest'
+import { findMatchingBrackets, type TextDocument, type Position } from './find-matching-brackets'
+
+/**
+ * Creates a simple TextDocument implementation from a string.
+ */
+function createDocument(content: string): TextDocument {
+  const lines = content.split('\n')
+  return {
+    getLine: (lineNumber: number) => lines[lineNumber] || '',
+    lineCount: lines.length,
+  }
+}
+
+describe('findMatchingBrackets', () => {
+  describe('basic bracket matching', () => {
+    it('matches simple opening and closing brackets', () => {
+      const doc = createDocument('::component\nSome content\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(2)
+      expect(result?.colonCount).toBe(2)
+    })
+
+    it('matches brackets when cursor is on closing bracket', () => {
+      const doc = createDocument('::component\nContent\n::')
+      const position: Position = { line: 2, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(2)
+    })
+
+    it('returns null when cursor is not on a bracket', () => {
+      const doc = createDocument('::component\nSome content\n::')
+      const position: Position = { line: 1, column: 5 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null when there is no matching bracket', () => {
+      const doc = createDocument('::component\nSome content')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('nested brackets', () => {
+    it('matches nested brackets with same colon count', () => {
+      const doc = createDocument('::outer\n::inner\nContent\n::\n::')
+      const position: Position = { line: 1, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(1)
+      expect(result?.closing.startLine).toBe(3)
+    })
+
+    it('matches outer bracket correctly', () => {
+      const doc = createDocument('::outer\n::inner\nContent\n::\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(4)
+    })
+
+    it('matches brackets with different colon counts (triple colons)', () => {
+      const doc = createDocument(':::outer\n::inner\nContent\n::\n:::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(4)
+      expect(result?.colonCount).toBe(3)
+    })
+
+    it('does not match brackets with different colon counts', () => {
+      const doc = createDocument('::component\n:::\nContent\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      // Should skip the ::: and find the ::
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(3)
+      expect(result?.colonCount).toBe(2)
+    })
+  })
+
+  describe('deeply nested structures', () => {
+    it('matches deeply nested brackets correctly', () => {
+      const doc = createDocument(
+        '::level1\n::level2\n::level3\nContent\n::\n::\n::',
+      )
+
+      // Match innermost bracket
+      const innerResult = findMatchingBrackets(doc, { line: 2, column: 0 })
+      expect(innerResult?.opening.startLine).toBe(2)
+      expect(innerResult?.closing.startLine).toBe(4)
+
+      // Match middle bracket
+      const middleResult = findMatchingBrackets(doc, { line: 1, column: 0 })
+      expect(middleResult?.opening.startLine).toBe(1)
+      expect(middleResult?.closing.startLine).toBe(5)
+
+      // Match outermost bracket
+      const outerResult = findMatchingBrackets(doc, { line: 0, column: 0 })
+      expect(outerResult?.opening.startLine).toBe(0)
+      expect(outerResult?.closing.startLine).toBe(6)
+    })
+
+    it('handles complex nesting with mixed colon counts', () => {
+      const doc = createDocument(
+        ':::outer\n::inner1\nContent\n::\n::inner2\nMore content\n::\n:::',
+      )
+
+      // Match first inner bracket
+      const inner1Result = findMatchingBrackets(doc, { line: 1, column: 0 })
+      expect(inner1Result?.opening.startLine).toBe(1)
+      expect(inner1Result?.closing.startLine).toBe(3)
+
+      // Match second inner bracket
+      const inner2Result = findMatchingBrackets(doc, { line: 4, column: 0 })
+      expect(inner2Result?.opening.startLine).toBe(4)
+      expect(inner2Result?.closing.startLine).toBe(6)
+
+      // Match outer bracket
+      const outerResult = findMatchingBrackets(doc, { line: 0, column: 0 })
+      expect(outerResult?.opening.startLine).toBe(0)
+      expect(outerResult?.closing.startLine).toBe(7)
+      expect(outerResult?.colonCount).toBe(3)
+    })
+  })
+
+  describe('code blocks', () => {
+    it('ignores brackets inside code blocks', () => {
+      const doc = createDocument(
+        '::component\n```\n::fake-component\n::\n```\n::',
+      )
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      // Should skip the brackets inside the code block
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(5)
+    })
+
+    it('ignores brackets inside tilde code blocks', () => {
+      const doc = createDocument(
+        '::component\n~~~\n::fake-component\n::\n~~~\n::',
+      )
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(5)
+    })
+  })
+
+  describe('cursor position detection', () => {
+    it('detects bracket when cursor is at the start of opening bracket', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('detects bracket when cursor is in the middle of component name', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 0, column: 5 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('detects bracket when cursor is at end of component name', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 0, column: 11 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('detects closing bracket when cursor is on colons', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 1, column: 1 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('does not detect bracket when cursor is after component name', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 0, column: 12 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('whitespace handling', () => {
+    it('handles opening brackets with leading whitespace', () => {
+      const doc = createDocument('  ::component\nContent\n  ::')
+      const position: Position = { line: 0, column: 2 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(2)
+    })
+
+    it('handles closing brackets with leading and trailing whitespace', () => {
+      const doc = createDocument('::component\nContent\n  ::  ')
+      const position: Position = { line: 2, column: 2 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startLine).toBe(0)
+      expect(result?.closing.startLine).toBe(2)
+    })
+  })
+
+  describe('component names', () => {
+    it('matches components with hyphens in name', () => {
+      const doc = createDocument('::my-component\nContent\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startColumn).toBe(0)
+      expect(result?.opening.endColumn).toBe(14) // length of "::my-component"
+    })
+
+    it('matches components with numbers in name', () => {
+      const doc = createDocument('::component123\nContent\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('matches components with underscores in name', () => {
+      const doc = createDocument('::my_component\nContent\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty document', () => {
+      const doc = createDocument('')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+
+    it('handles document with only opening bracket', () => {
+      const doc = createDocument('::component')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+
+    it('handles document with only closing bracket', () => {
+      const doc = createDocument('::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+
+    it('handles mismatched nesting', () => {
+      const doc = createDocument('::outer\n::inner\n::') // Missing closing for inner
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      // Inner bracket steals the only closing bracket, so outer has no match
+      expect(result).toBeNull()
+    })
+
+    it('returns null on error and logs warning', () => {
+      // Create a document that will cause an error during processing
+      const doc: TextDocument = {
+        getLine: () => {
+          throw new Error('Simulated error')
+        },
+        lineCount: 1,
+      }
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('range calculations', () => {
+    it('calculates correct ranges for opening bracket', () => {
+      const doc = createDocument('::component\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening).toEqual({
+        startLine: 0,
+        startColumn: 0,
+        endLine: 0,
+        endColumn: 11, // length of "::component"
+      })
+    })
+
+    it('calculates correct ranges for closing bracket', () => {
+      const doc = createDocument('::component\nContent\n::')
+      const position: Position = { line: 0, column: 0 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.closing).toEqual({
+        startLine: 2,
+        startColumn: 0,
+        endLine: 2,
+        endColumn: 2, // length of "::"
+      })
+    })
+
+    it('calculates correct ranges with leading whitespace', () => {
+      const doc = createDocument('  ::component\nContent\n  ::')
+      const position: Position = { line: 0, column: 2 }
+
+      const result = findMatchingBrackets(doc, position)
+
+      expect(result).not.toBeNull()
+      expect(result?.opening.startColumn).toBe(2)
+      expect(result?.opening.endColumn).toBe(13) // 2 (whitespace) + 11 (::component)
+      expect(result?.closing.startColumn).toBe(2)
+      expect(result?.closing.endColumn).toBe(4) // 2 (whitespace) + 2 (::)
+    })
+  })
+})

--- a/src/find-matching-brackets.ts
+++ b/src/find-matching-brackets.ts
@@ -1,0 +1,336 @@
+/**
+ * !Important: The exported functions in this file are also utilized in
+ * the `@nuxtlabs/vscode-mdc` VSCode extension https://github.com/nuxtlabs/vscode-mdc.
+ *
+ * Any changes to the function signatures or behavior should be tested and verified in the extension.
+ */
+
+/** Represents a text document, providing methods to access its content. */
+export interface TextDocument {
+  /**
+   * Retrieves the content of a specific line in the document.
+   * @param lineNumber - The zero-based line number to retrieve.
+   * @returns The content of the specified line.
+   */
+  getLine: (lineNumber: number) => string
+
+  /** The total number of lines in the document. */
+  lineCount: number
+}
+
+/**
+ * Represents a position in a text document (line and column).
+ */
+export interface Position {
+  /** Line number (zero-based). */
+  line: number
+  /** Column number (zero-based). */
+  column: number
+}
+
+/**
+ * Represents a range in a text document.
+ */
+export interface Range {
+  /** Starting line number (zero-based). */
+  startLine: number
+  /** Starting column number (zero-based). */
+  startColumn: number
+  /** Ending line number (zero-based). */
+  endLine: number
+  /** Ending column number (zero-based). */
+  endColumn: number
+}
+
+/**
+ * Represents a matched bracket pair with their positions.
+ */
+export interface BracketMatch {
+  /** Range of the opening bracket (e.g., `::component-name`) */
+  opening: Range
+  /** Range of the closing bracket (e.g., `::`) */
+  closing: Range
+  /** Number of colons in the matched pair */
+  colonCount: number
+}
+
+/**
+ * Internal representation of a block component bracket.
+ */
+interface BracketBlock {
+  line: number
+  colonCount: number
+  isOpening: boolean
+  /** For opening brackets, the tag name; for closing brackets, null */
+  tagName: string | null
+}
+
+/**
+ * Finds matching MDC block component brackets (:: markers) when cursor is adjacent to one.
+ *
+ * @param document - The text document to search
+ * @param position - The current cursor position
+ * @returns The matched bracket pair if found, otherwise null
+ */
+export function findMatchingBrackets(
+  document: TextDocument,
+  position: Position,
+): BracketMatch | null {
+  try {
+    const lineContent = document.getLine(position.line)
+
+    // Check if cursor is adjacent to a :: marker
+    const bracketAtCursor = detectBracketAtPosition(lineContent, position.column)
+
+    if (!bracketAtCursor) {
+      return null
+    }
+
+    // Build a map of all brackets in the document
+    const brackets = scanAllBrackets(document)
+    if (brackets.length === 0) {
+      return null
+    }
+
+    // Find the current bracket in our list
+    const currentBracketIndex = brackets.findIndex(
+      b => b.line === position.line,
+    )
+    if (currentBracketIndex === -1) {
+      return null
+    }
+
+    const currentBracket = brackets[currentBracketIndex]
+    const matchingBracket = findMatchingBracket(brackets, currentBracketIndex)
+
+    if (!matchingBracket) {
+      return null
+    }
+
+    // Return the match with brackets in correct order
+    return {
+      opening: createBracketRange(
+        document,
+        currentBracket.isOpening ? currentBracket : matchingBracket,
+      ),
+      closing: createBracketRange(
+        document,
+        currentBracket.isOpening ? matchingBracket : currentBracket,
+      ),
+      colonCount: currentBracket.colonCount,
+    }
+  }
+  catch (error) {
+    // Fail silently to avoid breaking the editor
+    console.warn('[MDC Bracket Matcher] Error finding matching brackets:', error)
+    return null
+  }
+}
+
+/**
+ * Detects if the cursor is adjacent to a :: marker and returns its colon count.
+ *
+ * Checks for:
+ * - Opening brackets: `::component-name` (cursor anywhere on the line)
+ * - Closing brackets: `::` alone (cursor within or adjacent to colons)
+ *
+ * @returns Object with colon count if cursor is on a bracket, null otherwise
+ */
+function detectBracketAtPosition(
+  lineContent: string,
+  column: number,
+): { colonCount: number } | null {
+  // Check for opening bracket: ::component-name
+  const openingMatch = lineContent.match(/^\s*(:{2,})([\w-]+)/)
+  if (openingMatch) {
+    const colonCount = openingMatch[1].length
+    const colonStart = openingMatch.index! + openingMatch[0].indexOf(openingMatch[1])
+    const componentNameEnd = colonStart + openingMatch[1].length + openingMatch[2].length
+
+    // Cursor should be within or adjacent to the colons or component name
+    if (column >= colonStart && column <= componentNameEnd) {
+      return { colonCount }
+    }
+  }
+
+  // Check for closing bracket: ::
+  const closingMatch = lineContent.match(/^\s*(:{2,})\s*$/)
+  if (closingMatch) {
+    const colonCount = closingMatch[1].length
+    const colonStart = closingMatch.index! + closingMatch[0].indexOf(closingMatch[1])
+    const colonEnd = colonStart + colonCount
+
+    // Cursor should be within or adjacent to the colons
+    if (column >= colonStart && column <= colonEnd) {
+      return { colonCount }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Scans the entire document for all block component brackets.
+ *
+ * Note: This performs a full document scan on each cursor movement.
+ * For large documents, this could be optimized by caching results
+ * and incrementally updating on document changes.
+ */
+function scanAllBrackets(document: TextDocument): BracketBlock[] {
+  const brackets: BracketBlock[] = []
+  let insideCodeBlock = false
+
+  for (let lineNumber = 0; lineNumber < document.lineCount; lineNumber++) {
+    const lineContent = document.getLine(lineNumber)
+    const trimmed = lineContent.trim()
+
+    // Check for code block markers
+    if (/^\s*(?:`{3,}|~{3,})/.test(trimmed)) {
+      insideCodeBlock = !insideCodeBlock
+      continue
+    }
+
+    // Skip lines inside markdown code blocks
+    if (insideCodeBlock) {
+      continue
+    }
+
+    // Match opening brackets: ::component-name
+    const openingMatch = trimmed.match(/^(:{2,})([\w-]+)/)
+    if (openingMatch) {
+      brackets.push({
+        line: lineNumber,
+        colonCount: openingMatch[1].length,
+        isOpening: true,
+        tagName: openingMatch[2],
+      })
+      continue
+    }
+
+    // Match closing brackets: ::
+    const closingMatch = trimmed.match(/^(:{2,})$/)
+    if (closingMatch) {
+      brackets.push({
+        line: lineNumber,
+        colonCount: closingMatch[1].length,
+        isOpening: false,
+        tagName: null,
+      })
+    }
+  }
+
+  return brackets
+}
+
+/**
+ * Finds the matching bracket for a given bracket using stack-based matching.
+ * Only matches brackets with identical colon counts (:: matches :: but not :::).
+ *
+ * Algorithm:
+ * - For opening brackets: scan forward, using a stack to track nesting
+ * - For closing brackets: scan backward, using a stack to track nesting
+ * - Pop from stack when matching colon count is found
+ * - Return match when stack is empty
+ */
+function findMatchingBracket(
+  brackets: BracketBlock[],
+  currentIndex: number,
+): BracketBlock | null {
+  const currentBracket = brackets[currentIndex]
+
+  if (currentBracket.isOpening) {
+    // Find matching closing bracket forward
+    const stack: BracketBlock[] = [currentBracket]
+
+    for (let i = currentIndex + 1; i < brackets.length; i++) {
+      const bracket = brackets[i]
+
+      if (bracket.isOpening) {
+        stack.push(bracket)
+      }
+      else {
+        const lastOpening = stack[stack.length - 1]
+        if (lastOpening && lastOpening.colonCount === bracket.colonCount) {
+          stack.pop()
+          if (stack.length === 0) {
+            return bracket
+          }
+        }
+      }
+    }
+  }
+  else {
+    // Find matching opening bracket backward
+    const stack: BracketBlock[] = [currentBracket]
+
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      const bracket = brackets[i]
+
+      if (!bracket.isOpening) {
+        stack.push(bracket)
+      }
+      else {
+        const lastClosing = stack[stack.length - 1]
+        if (lastClosing && lastClosing.colonCount === bracket.colonCount) {
+          stack.pop()
+          if (stack.length === 0) {
+            return bracket
+          }
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Creates a Range for a bracket.
+ *
+ * For opening brackets, includes the colons and component name (e.g., `::component-name`).
+ * For closing brackets, includes only the colons (e.g., `::`).
+ */
+function createBracketRange(
+  document: TextDocument,
+  bracket: BracketBlock,
+): Range {
+  const lineNumber = bracket.line
+  const lineContent = document.getLine(lineNumber)
+
+  if (bracket.isOpening) {
+    // Match the colons and component name
+    const match = lineContent.match(/(:{2,})([\w-]+)/)
+    if (match) {
+      const startColumn = lineContent.indexOf(match[0])
+      const endColumn = startColumn + match[0].length
+      return {
+        startLine: lineNumber,
+        startColumn,
+        endLine: lineNumber,
+        endColumn,
+      }
+    }
+  }
+  else {
+    // Match just the colons
+    const match = lineContent.match(/(:{2,})$/)
+    if (match) {
+      const startColumn = lineContent.lastIndexOf(match[0])
+      const endColumn = startColumn + match[0].length
+      return {
+        startLine: lineNumber,
+        startColumn,
+        endLine: lineNumber,
+        endColumn,
+      }
+    }
+  }
+
+  // Fallback to entire line
+  return {
+    startLine: lineNumber,
+    startColumn: 0,
+    endLine: lineNumber,
+    endColumn: lineContent.length,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,3 +255,5 @@ export const language = <languages.IMonarchLanguage>{
 export { formatter } from './formatter'
 export { foldingProvider } from './folding-provider'
 export { getDocumentFoldingRanges } from './get-document-folding-ranges'
+export { registerBracketMatcher } from './bracket-matcher'
+export { findMatchingBrackets } from './find-matching-brackets'


### PR DESCRIPTION
Adds a new `registerBracketMatcher` utility that provides MDC block component opening and closing tag color matching when cursor is active, along with integration instructions via the README.

> [!NOTE]
> The new exported function(s) are also utilized in the `@nuxtlabs/vscode-mdc` VSCode extension via https://github.com/nuxt-content/vscode-mdc/pull/77 and should be tested there before future modification

<details>

<summary>Click to copy example MDC content</summary>

```md
::page-section
---
full-width: true
---
  :::page-header
  ---
  title: "MDC block component matches"
  description: "The component opening and closing tags are now highlighted ✨"
  ---
    ::container
    This is in the inner-most component.
    ::
  :::
::
```

</details>

<img width="753" height="330" alt="MDC block component matching" src="https://github.com/user-attachments/assets/dd0f4680-ae99-4af7-b890-759840608765" />